### PR TITLE
Prefix vendor dir with heroku app $HOME

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,5 +20,5 @@ curl -L --silent $DOWNLOAD_URL | tar xz
 echo "exporting PATH and LIBRARY_PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/ffmpeg.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo 'export PATH="$PATH:vendor/ffmpeg/bin"' >> $PROFILE_PATH
-echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:vendor/ffmpeg/lib:vendor/faac/lib:vendor/libogg/lib:vendor/libvorbis/lib:vendor/mp3lame/lib:vendor/x264/lib"' >> $PROFILE_PATH
+echo 'export PATH="$PATH:$HOME/vendor/ffmpeg/bin"' >> $PROFILE_PATH
+echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/vendor/ffmpeg/lib:$HOME/vendor/faac/lib:$HOME/vendor/libogg/lib:$HOME/vendor/libvorbis/lib:$HOME/vendor/mp3lame/lib:$HOME/vendor/x264/lib"' >> $PROFILE_PATH


### PR DESCRIPTION
Rails app cannot not locate and does not have permissions to run the ffmpeg binary unless the vendor paths are prefixed with $HOME.
